### PR TITLE
Support = as a separator for short options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 New:
 
+- Support `=` as a separator for short options (as in `-o=value`).
 - Document how to use `Parser::value()` to collect all remaining arguments.
 
 Bug fixes:

--- a/README.md
+++ b/README.md
@@ -92,13 +92,12 @@ The following conventions are supported:
 - Short options (`-q`)
 - Long options (`--verbose`)
 - `--` to mark the end of options
-- `=` to separate long options from values (`--option=value`)
-- Spaces to separate options from values (`--option value`, `-f value`)
-- Unseparated short options (`-fvalue`)
+- `=` to separate options from values (`--option=value`, `-o=value`)
+- Spaces to separate options from values (`--option value`, `-o value`)
+- Unseparated short options (`-ovalue`)
 - Combined short options (`-abc` to mean `-a -b -c`)
 
 These are not supported:
-- `-f=value` for short options
 - Options with optional arguments (like GNU sed's `-i`, which can be used standalone or as `-iSUFFIX`)
 - Single-dash long options (like find's `-name`)
 - Abbreviated long options (GNU's getopt lets you write `--num` instead of `--number` if it can be expanded unambiguously)


### PR DESCRIPTION
Resolves #8. @theIDinside, maybe you'd like to take a look?

I made these choices:
- If `=` is found when no value is expected it's just treated as a short option. Clap also does this. (I wanted to make it an error first, but didn't know what to do with `-=`.) (ETA: after this PR I decided to turn it into an error after all, except in the `-=` case, where it stays a short option.)
- `=` is allowed for combined short options, like `-xo=value`. Clap does this, argparse doesn't.
- It has to be at most a single `=`. Clap allows multiple, like `-o========value`.