### PR TITLE
Use std::vec::IntoIter as Parser's backing iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.3.0 (unreleased)
+
+The input iterator is now consumed when you create a `Parser`, instead of during parsing. This breaks certain clever code that inspects the state of the iterator, but the newly added unlimited lookahead may provide an alternative.
+
+(If you don't know what this means then you don't have to worry.)
+
+New:
+
+- Add `RawArgs::as_slice()` for unlimited lookahead.
+- `Parser` implements `Clone`, `Send`, and `Sync`. Its `Debug` output now shows the remaining arguments.
+
 ## 0.2.1 (2022-07-10)
 
 New:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,7 +31,7 @@ I see three ways to store `Parser`'s internal iterator:
 2. As a trait object (`source: Box<dyn Iterator<Item = OsString> + 'static>`)
 3. As a particular known type (`source: std::vec::IntoIter<OsString>`)
 
-I went with option 2 but I suspect option 3 is better. Changing this would technically not be backward compatible.
+lexopt originally used option 2 but switched to option 3.
 
 **Option 1** (generic field) is the most general and powerful but it's cumbersome and bloated. Benefits:
 


### PR DESCRIPTION
lexopt currently uses `Box<dyn Iterator>` but this is very restrictive. By switching to a vector's iterator we can derive common traits like `Clone` and get unlimited look-ahead.

This isn't strictly backward-compatible. The iterator is now exhausted when you create the parser, not during parsing. Sufficiently perverse code like [this](https://gist.github.com/blyxxyz/06b45c82c4a4f1030a89e0289adebf09) can observe it, and it might be out in the wild, so I'm bumping the version to 0.3.0. Such code can hopefully use `RawArgs::as_slice()` instead, especially when #15 is implemented.

`Parser` could implement `FromIterator` now, and `RawArgs` could provide mutable access, but I'm not sure those are useful so I left them out.

Both this change and the version bump seem like the right thing to do, but comments welcome.

cc @nordzilla @tertsdiepraam