### PR TITLE
Add `Parser::set_short_equals()` setting for disabling `-o=value`

### DIFF
--- a/.github/setup_wasmtime.sh
+++ b/.github/setup_wasmtime.sh
@@ -6,7 +6,7 @@ if test -z "$RUNNER_OS"; then
     exit 1
 fi
 
-url=https://github.com/bytecodealliance/wasmtime/releases/download/v31.0.0/wasmtime-v31.0.0-x86_64-linux.tar.xz
+url=https://github.com/bytecodealliance/wasmtime/releases/download/v42.0.1/wasmtime-v42.0.1-x86_64-linux.tar.xz
 
 cd /tmp
 curl -L "$url" | tar Jx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.2 (unreleased)
+
+New:
+
+- Add `Parser::set_short_equals()` to optionally disable the nonstandard `-o=value` syntax.
+
 ## 0.3.1 (2025-03-31)
 
 New:
@@ -62,4 +68,5 @@ Bug fixes:
 - Include `bin_name` in `Parser`'s `Debug` output.
 
 ## 0.1.0 (2021-07-16)
+
 Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 0.3.2 (unreleased)
+## 0.3.2 (2025-02-28)
 
 New:
 
-- Add `Parser::set_short_equals()` to optionally disable the nonstandard `-o=value` syntax.
+- Add `Parser::set_short_equals()` to opt out of the nonstandard `-o=value` syntax.
 
 ## 0.3.1 (2025-03-31)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lexopt"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Jan Verbeek <jan.verbeek@posteo.nl>"]
 description = "Minimalist pedantic command line parser"
 keywords = ["args", "arguments", "cli", "parser", "getopt"]

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The following conventions are supported:
 - Long options (`--verbose`)
 - `--` to mark the end of options
 - `=` to separate options from values (`--option=value`, `-o=value`)
+  - The nonstandard `-o=value` syntax can be [disabled](https://docs.rs/lexopt/latest/lexopt/struct.Parser.html#method.set_short_equals).
 - Spaces to separate options from values (`--option value`, `-o value`)
 - Unseparated short options (`-ovalue`)
 - Combined short options (`-abc` to mean `-a -b -c`)

--- a/examples/posixly_correct.rs
+++ b/examples/posixly_correct.rs
@@ -10,11 +10,15 @@
 //!
 //! Note that most modern software doesn't follow POSIX's rule and allows
 //! options anywhere (as long as they come before "--").
+//!
+//! [`short_equals`][lexopt::Parser::set_short_equals] also diverges
+//! from POSIX (but is otherwise unrelated).
 
 fn main() -> Result<(), lexopt::Error> {
     use lexopt::prelude::*;
 
     let mut parser = lexopt::Parser::from_env();
+    parser.set_short_equals(false);
     let mut free = Vec::new();
     while let Some(arg) = parser.next()? {
         match arg {

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -16,6 +16,11 @@ fuzz_target!(|data: &[u8]| {
     } else {
         decisions = 0;
     }
+    let mut set_short_equals = true;
+    if data.len() >= 1 {
+        set_short_equals = data[0] % 2 == 0;
+        data = &data[1..];
+    }
     let data: Vec<_> = data
         // Arguments can't contain null bytes (on Unix) so it's a
         // reasonable separator
@@ -24,6 +29,7 @@ fuzz_target!(|data: &[u8]| {
         .map(OsString::from_vec)
         .collect();
     let mut p = lexopt::Parser::from_args(data);
+    p.set_short_equals(set_short_equals);
     loop {
         // 0 -> Parser::next()
         // 1 -> Parser::value()


### PR DESCRIPTION
Since v0.2.0 `-o=value` has been parsed as option `-o` with value `value`. This is nonstandard but compatible with `clap`.

This PR adds a `parse_short_equals(bool)` method to configure this. If disabled the equals sign is treated as part of the value, i.e. `-o` with value `=value`.

This is for example useful for `cut`'s `-d` option, which is often invoked as `cut -d=`. That makes it relevant for https://github.com/uutils/uutils-args.

Resolves #13.

cc @tertsdiepraam